### PR TITLE
Intial systemd-nspawn support for priority based partition selection (DO NOT MERGE)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2830,14 +2830,16 @@ systemd_nspawn_SOURCES = \
 systemd_nspawn_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(SECCOMP_CFLAGS) \
-	$(BLKID_CFLAGS)
+	$(BLKID_CFLAGS) \
+	$(LIBFDISK_CFLAGS)
 
 systemd_nspawn_LDADD = \
 	libsystemd-label.la \
 	libudev-internal.la \
 	libsystemd-internal.la \
 	libsystemd-shared.la \
-	$(BLKID_LIBS)
+	$(BLKID_LIBS) \
+	$(LIBFDISK_LIBS)
 
 if HAVE_SECCOMP
 systemd_nspawn_LDADD += \

--- a/configure.ac
+++ b/configure.ac
@@ -450,6 +450,18 @@ fi
 AM_CONDITIONAL(HAVE_BLKID, [test "$have_blkid" = "yes"])
 
 # ------------------------------------------------------------------------------
+have_libfdisk=no
+AC_ARG_ENABLE(libfdisk, AS_HELP_STRING([--disable-libfdisk], [disable libfdisk support]))
+if test "x$enable_libfdisk" != "xno"; then
+        PKG_CHECK_MODULES(LIBFDISK, [ fdisk >= 2.27 ],
+                [AC_DEFINE(HAVE_LIBFDISK, 1, [Define if libfdisk is available]) have_libfdisk=yes], have_libfdisk=no)
+        if test "x$have_libfdisk" = xno -a "x$enable_libfdisk" = xyes; then
+                AC_MSG_ERROR([*** libfdisk support requested but libraries not found])
+        fi
+fi
+AM_CONDITIONAL(HAVE_LIBFDISK, [test "$have_libfdisk" = "yes"])
+
+# ------------------------------------------------------------------------------
 have_libmount=no
 PKG_CHECK_MODULES(MOUNT, [ mount >= 2.20 ],
         [AC_DEFINE(HAVE_LIBMOUNT, 1, [Define if libmount is available]) have_libmount=yes], have_libmount=no)
@@ -1579,6 +1591,7 @@ AC_MSG_RESULT([
         kmod:                    ${have_kmod}
         xkbcommon:               ${have_xkbcommon}
         blkid:                   ${have_blkid}
+        libfdisk:                ${have_libfdisk}
         libmount:                ${have_libmount}
         dbus:                    ${have_dbus}
         nss-myhostname:          ${have_myhostname}

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -125,6 +125,16 @@ typedef enum Volatile {
         VOLATILE_STATE,
 } Volatile;
 
+typedef struct Partition {
+        char *node;
+        int index;
+        bool read_only;
+} Partition;
+
+static void partition_free(Partition *p);
+DEFINE_TRIVIAL_CLEANUP_FUNC(Partition*, partition_free);
+#define _cleanup_partition_free_ _cleanup_(partition_freep)
+
 static char *arg_directory = NULL;
 static char *arg_template = NULL;
 static char *arg_user = NULL;
@@ -2767,6 +2777,39 @@ static int setup_image(char **device_path, int *loop_nr) {
         return r;
 }
 
+static Partition* partition_new(const char *node, int index, uint64_t flags) {
+        Partition *p;
+
+        /* As with libblkid, the partition numbers start at 1. */
+        assert(node);
+        assert(index > 0);
+
+        p = malloc(sizeof(Partition));
+        if (!p)
+                return NULL;
+
+        p->node = strdup(node);
+        if (!p->node) {
+                free(p);
+                return NULL;
+        }
+
+        p->index = index;
+        p->read_only = !!(flags & GPT_FLAG_READ_ONLY);
+        p->successful = !!(flags & GPT_FLAG_SUCCESSFUL);
+
+        return p;
+}
+
+static void partition_free(Partition *p) {
+
+        if (!p)
+                return;
+
+        free(p->node);
+        free(p);
+}
+
 #define PARTITION_TABLE_BLURB \
         "Note that the disk image needs to either contain only a single MBR partition of\n" \
         "type 0x83 that is marked bootable, or a single GPT partition of type " \
@@ -2776,26 +2819,24 @@ static int setup_image(char **device_path, int *loop_nr) {
 
 static int dissect_image(
                 int fd,
-                char **root_device, bool *root_device_rw,
-                char **home_device, bool *home_device_rw,
-                char **srv_device, bool *srv_device_rw,
+                Partition **root_device,
+                Partition **home_device,
+                Partition **srv_device,
                 bool *secondary) {
 
 #ifdef HAVE_BLKID
-        int home_nr = -1, srv_nr = -1;
+        _cleanup_partition_free_ Partition *generic = NULL, *home = NULL, *srv = NULL;
 #ifdef GPT_ROOT_NATIVE
-        int root_nr = -1;
+        _cleanup_partition_free_ Partition *root = NULL;
 #endif
 #ifdef GPT_ROOT_SECONDARY
-        int secondary_root_nr = -1;
+        _cleanup_partition_free_ Partition *secondary_root = NULL;
 #endif
-        _cleanup_free_ char *home = NULL, *root = NULL, *secondary_root = NULL, *srv = NULL, *generic = NULL;
         _cleanup_udev_enumerate_unref_ struct udev_enumerate *e = NULL;
         _cleanup_udev_device_unref_ struct udev_device *d = NULL;
         _cleanup_blkid_free_probe_ blkid_probe b = NULL;
         _cleanup_udev_unref_ struct udev *udev = NULL;
         struct udev_list_entry *first, *item;
-        bool home_rw = true, root_rw = true, secondary_root_rw = true, srv_rw = true, generic_rw = true;
         bool is_gpt, is_mbr, multiple_generic = false;
         const char *pttype = NULL;
         blkid_partlist pl;
@@ -2950,7 +2991,7 @@ static int dissect_image(
         udev_list_entry_foreach(item, first) {
                 _cleanup_udev_device_unref_ struct udev_device *q;
                 const char *node;
-                unsigned long long flags;
+                uint64_t flags;
                 blkid_partition pp;
                 dev_t qn;
                 int nr;
@@ -3002,53 +3043,45 @@ static int dissect_image(
 
                         if (sd_id128_equal(type_id, GPT_HOME)) {
 
-                                if (home && nr >= home_nr)
+                                if (home && nr >= home->index)
                                         continue;
 
-                                home_nr = nr;
-                                home_rw = !(flags & GPT_FLAG_READ_ONLY);
-
-                                r = free_and_strdup(&home, node);
-                                if (r < 0)
+                                partition_free(home);
+                                home = partition_new(node, nr, flags);
+                                if (!home)
                                         return log_oom();
 
                         } else if (sd_id128_equal(type_id, GPT_SRV)) {
 
-                                if (srv && nr >= srv_nr)
+                                if (srv && nr >= srv->index)
                                         continue;
 
-                                srv_nr = nr;
-                                srv_rw = !(flags & GPT_FLAG_READ_ONLY);
-
-                                r = free_and_strdup(&srv, node);
-                                if (r < 0)
+                                partition_free(srv);
+                                srv = partition_new(node, nr, flags);
+                                if (!srv)
                                         return log_oom();
                         }
 #ifdef GPT_ROOT_NATIVE
                         else if (sd_id128_equal(type_id, GPT_ROOT_NATIVE)) {
 
-                                if (root && nr >= root_nr)
+                                if (root && nr >= root->index)
                                         continue;
 
-                                root_nr = nr;
-                                root_rw = !(flags & GPT_FLAG_READ_ONLY);
-
-                                r = free_and_strdup(&root, node);
-                                if (r < 0)
+                                partition_free(root);
+                                root = partition_new(node, nr, flags);
+                                if (!root)
                                         return log_oom();
                         }
 #endif
 #ifdef GPT_ROOT_SECONDARY
                         else if (sd_id128_equal(type_id, GPT_ROOT_SECONDARY)) {
 
-                                if (secondary_root && nr >= secondary_root_nr)
+                                if (secondary_root && nr >= secondary_root->index)
                                         continue;
 
-                                secondary_root_nr = nr;
-                                secondary_root_rw = !(flags & GPT_FLAG_READ_ONLY);
-
-                                r = free_and_strdup(&secondary_root, node);
-                                if (r < 0)
+                                partition_free(secondary_root);
+                                secondary_root = partition_new(node, nr, flags);
+                                if (!secondary_root)
                                         return log_oom();
                         }
 #endif
@@ -3057,10 +3090,8 @@ static int dissect_image(
                                 if (generic)
                                         multiple_generic = true;
                                 else {
-                                        generic_rw = !(flags & GPT_FLAG_READ_ONLY);
-
-                                        r = free_and_strdup(&generic, node);
-                                        if (r < 0)
+                                        generic = partition_new(node, nr, flags);
+                                        if (!generic)
                                                 return log_oom();
                                 }
                         }
@@ -3078,10 +3109,8 @@ static int dissect_image(
                         if (generic)
                                 multiple_generic = true;
                         else {
-                                generic_rw = true;
-
-                                r = free_and_strdup(&root, node);
-                                if (r < 0)
+                                generic = partition_new(node, nr, 0);
+                                if (!generic)
                                         return log_oom();
                         }
                 }
@@ -3091,13 +3120,11 @@ static int dissect_image(
                 *root_device = root;
                 root = NULL;
 
-                *root_device_rw = root_rw;
                 *secondary = false;
         } else if (secondary_root) {
                 *root_device = secondary_root;
                 secondary_root = NULL;
 
-                *root_device_rw = secondary_root_rw;
                 *secondary = true;
         } else if (generic) {
 
@@ -3117,7 +3144,6 @@ static int dissect_image(
                 *root_device = generic;
                 generic = NULL;
 
-                *root_device_rw = generic_rw;
                 *secondary = false;
         } else {
                 log_error("Failed to identify root partition in disk image\n"
@@ -3129,15 +3155,11 @@ static int dissect_image(
         if (home) {
                 *home_device = home;
                 home = NULL;
-
-                *home_device_rw = home_rw;
         }
 
         if (srv) {
                 *srv_device = srv;
                 srv = NULL;
-
-                *srv_device_rw = srv_rw;
         }
 
         return 0;
@@ -3147,17 +3169,18 @@ static int dissect_image(
 #endif
 }
 
-static int mount_device(const char *what, const char *where, const char *directory, bool rw) {
+static int mount_device(const Partition *what, const char *where, const char *directory) {
 #ifdef HAVE_BLKID
         _cleanup_blkid_free_probe_ blkid_probe b = NULL;
         const char *fstype, *p;
+        bool ro;
         int r;
 
         assert(what);
+        assert(what->node);
         assert(where);
 
-        if (arg_read_only)
-                rw = false;
+        ro = arg_read_only || what->read_only;
 
         if (directory)
                 p = strjoina(where, directory);
@@ -3165,11 +3188,11 @@ static int mount_device(const char *what, const char *where, const char *directo
                 p = where;
 
         errno = 0;
-        b = blkid_new_probe_from_filename(what);
+        b = blkid_new_probe_from_filename(what->node);
         if (!b) {
                 if (errno == 0)
                         return log_oom();
-                log_error_errno(errno, "Failed to allocate prober for %s: %m", what);
+                log_error_errno(errno, "Failed to allocate prober for %s: %m", what->node);
                 return -errno;
         }
 
@@ -3179,12 +3202,12 @@ static int mount_device(const char *what, const char *where, const char *directo
         errno = 0;
         r = blkid_do_safeprobe(b);
         if (r == -1 || r == 1) {
-                log_error("Cannot determine file system type of %s", what);
+                log_error("Cannot determine file system type of %s", what->node);
                 return -EINVAL;
         } else if (r != 0) {
                 if (errno == 0)
                         errno = EIO;
-                log_error_errno(errno, "Failed to probe %s: %m", what);
+                log_error_errno(errno, "Failed to probe %s: %m", what->node);
                 return -errno;
         }
 
@@ -3192,7 +3215,7 @@ static int mount_device(const char *what, const char *where, const char *directo
         if (blkid_probe_lookup_value(b, "TYPE", &fstype, NULL) < 0) {
                 if (errno == 0)
                         errno = EINVAL;
-                log_error("Failed to determine file system type of %s", what);
+                log_error("Failed to determine file system type of %s", what->node);
                 return -errno;
         }
 
@@ -3201,8 +3224,8 @@ static int mount_device(const char *what, const char *where, const char *directo
                 return -EOPNOTSUPP;
         }
 
-        if (mount(what, p, fstype, MS_NODEV|(rw ? 0 : MS_RDONLY), NULL) < 0)
-                return log_error_errno(errno, "Failed to mount %s: %m", what);
+        if (mount(what->node, p, fstype, MS_NODEV|(ro ? MS_RDONLY : 0), NULL) < 0)
+                return log_error_errno(errno, "Failed to mount %s: %m", what->node);
 
         return 0;
 #else
@@ -3213,27 +3236,27 @@ static int mount_device(const char *what, const char *where, const char *directo
 
 static int mount_devices(
                 const char *where,
-                const char *root_device, bool root_device_rw,
-                const char *home_device, bool home_device_rw,
-                const char *srv_device, bool srv_device_rw) {
+                const Partition *root_device,
+                const Partition *home_device,
+                const Partition *srv_device) {
         int r;
 
         assert(where);
 
         if (root_device) {
-                r = mount_device(root_device, arg_directory, NULL, root_device_rw);
+                r = mount_device(root_device, arg_directory, NULL);
                 if (r < 0)
                         return log_error_errno(r, "Failed to mount root directory: %m");
         }
 
         if (home_device) {
-                r = mount_device(home_device, arg_directory, "/home", home_device_rw);
+                r = mount_device(home_device, arg_directory, "/home");
                 if (r < 0)
                         return log_error_errno(r, "Failed to mount home directory: %m");
         }
 
         if (srv_device) {
-                r = mount_device(srv_device, arg_directory, "/srv", srv_device_rw);
+                r = mount_device(srv_device, arg_directory, "/srv");
                 if (r < 0)
                         return log_error_errno(r, "Failed to mount server data directory: %m");
         }
@@ -3695,8 +3718,9 @@ static int determine_uid_shift(void) {
 
 int main(int argc, char *argv[]) {
 
-        _cleanup_free_ char *device_path = NULL, *root_device = NULL, *home_device = NULL, *srv_device = NULL, *console = NULL;
-        bool root_device_rw = true, home_device_rw = true, srv_device_rw = true;
+        _cleanup_free_ char *device_path = NULL, *console = NULL;
+        _cleanup_partition_free_ Partition *root_device = NULL,
+                                 *home_device = NULL, *srv_device = NULL;
         _cleanup_close_ int master = -1, image_fd = -1;
         _cleanup_fdset_free_ FDSet *fds = NULL;
         int r, n_fd_passed, loop_nr = -1;
@@ -3867,9 +3891,9 @@ int main(int argc, char *argv[]) {
                 }
 
                 r = dissect_image(image_fd,
-                                  &root_device, &root_device_rw,
-                                  &home_device, &home_device_rw,
-                                  &srv_device, &srv_device_rw,
+                                  &root_device,
+                                  &home_device,
+                                  &srv_device,
                                   &secondary);
                 if (r < 0)
                         goto finish;
@@ -4041,9 +4065,9 @@ int main(int argc, char *argv[]) {
                         }
 
                         if (mount_devices(arg_directory,
-                                          root_device, root_device_rw,
-                                          home_device, home_device_rw,
-                                          srv_device, srv_device_rw) < 0)
+                                          root_device,
+                                          home_device,
+                                          srv_device) < 0)
                                 _exit(EXIT_FAILURE);
 
                         /* Turn directory into bind mount */

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -1485,7 +1485,13 @@ static int copy_devnode(const char *dest, const char *from) {
         return 0;
 }
 
-static int copy_devnodes(const char *dest) {
+static int copy_devnodes(
+                const char *dest,
+                const char *disk_device,
+                const Partition *root_device,
+                const Partition *usr_device,
+                const Partition *home_device,
+                const Partition *srv_device) {
 
         static const char devnodes[] =
                 "/dev/null\0"
@@ -1501,6 +1507,36 @@ static int copy_devnodes(const char *dest) {
 
         NULSTR_FOREACH(d, devnodes) {
                 r = copy_devnode(dest, d);
+                if (r < 0)
+                        return r;
+        }
+
+        if (disk_device) {
+                r = copy_devnode(dest, disk_device);
+                if (r < 0)
+                        return r;
+        }
+
+        if (root_device) {
+                r = copy_devnode(dest, root_device->node);
+                if (r < 0)
+                        return r;
+        }
+
+        if (usr_device) {
+                r = copy_devnode(dest, usr_device->node);
+                if (r < 0)
+                        return r;
+        }
+
+        if (home_device) {
+                r = copy_devnode(dest, home_device->node);
+                if (r < 0)
+                        return r;
+        }
+
+        if (srv_device) {
+                r = copy_devnode(dest, srv_device->node);
                 if (r < 0)
                         return r;
         }
@@ -4279,7 +4315,12 @@ int main(int argc, char *argv[]) {
                         if (mount_all(arg_directory) < 0)
                                 _exit(EXIT_FAILURE);
 
-                        if (copy_devnodes(arg_directory) < 0)
+                        if (copy_devnodes(arg_directory,
+                                          device_path,
+                                          root_device,
+                                          usr_device,
+                                          home_device,
+                                          srv_device) < 0)
                                 _exit(EXIT_FAILURE);
 
                         if (setup_ptmx(arg_directory) < 0)

--- a/src/shared/gpt.h
+++ b/src/shared/gpt.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <endian.h>
+#include <stdint.h>
 
 #include "sd-id128.h"
 
@@ -70,5 +71,21 @@
  * just because we saw no point in defining any other values here. */
 #define GPT_FLAG_READ_ONLY (1ULL << 60)
 #define GPT_FLAG_NO_AUTO (1ULL << 63)
+
+/* Flags for prioritizing multiple ROOT or USR partitions of the same type.
+ * SUCCESSFUL is a single bit while TRIES and PRIORITY are 4 bits each. */
+#define GPT_FLAG_SUCCESSFUL (1ULL << 56)
+#define GPT_FLAG_TRIES_OFFSET 52
+#define GPT_FLAG_TRIES_MAX 15ULL
+#define GPT_FLAG_PRIORITY_OFFSET 48
+#define GPT_FLAG_PRIORITY_MAX 15ULL
+
+static inline uint8_t gpt_flag_tries(uint64_t flags) {
+        return (uint8_t)((flags >> GPT_FLAG_TRIES_OFFSET) & GPT_FLAG_TRIES_MAX);
+}
+
+static inline uint8_t gpt_flag_priority(uint64_t flags) {
+        return (uint8_t)((flags >> GPT_FLAG_PRIORITY_OFFSET) & GPT_FLAG_PRIORITY_MAX);
+}
 
 #define GPT_LINUX_GENERIC SD_ID128_MAKE(0f,c6,3d,af,84,83,47,72,8e,79,3d,69,d8,47,7d,e4)

--- a/src/shared/gpt.h
+++ b/src/shared/gpt.h
@@ -34,6 +34,11 @@
 #define GPT_ROOT_ARM    SD_ID128_MAKE(69,da,d7,10,2c,e4,4e,3c,b1,6c,21,a1,d4,9a,be,d3)
 #define GPT_ROOT_ARM_64 SD_ID128_MAKE(b9,21,b0,45,1d,f0,41,c3,af,44,4c,6f,28,0d,3f,ae)
 
+#define GPT_USR_X86     SD_ID128_MAKE(ef,ec,21,e4,2f,c7,4b,01,83,93,32,9f,a4,05,a5,2d)
+#define GPT_USR_X86_64  SD_ID128_MAKE(5d,fb,f5,f4,28,48,4b,ac,aa,5e,0d,9a,20,b7,45,a6)
+#define GPT_USR_ARM     SD_ID128_MAKE(7c,b2,1d,01,6b,ed,40,cc,8d,ea,d8,a6,2f,69,18,62)
+#define GPT_USR_ARM_64  SD_ID128_MAKE(fb,b1,aa,b9,b9,76,45,11,b2,c4,d4,15,2f,82,13,b9)
+
 #define GPT_ESP         SD_ID128_MAKE(c1,2a,73,28,f8,1f,11,d2,ba,4b,00,a0,c9,3e,c9,3b)
 #define GPT_SWAP        SD_ID128_MAKE(06,57,fd,6d,a4,ab,43,c4,84,e5,09,33,c8,4b,4f,4f)
 #define GPT_HOME        SD_ID128_MAKE(93,3a,c7,e1,2e,b4,4f,13,b8,44,0e,14,e2,ae,f9,15)
@@ -42,15 +47,21 @@
 #if defined(__x86_64__)
 #  define GPT_ROOT_NATIVE GPT_ROOT_X86_64
 #  define GPT_ROOT_SECONDARY GPT_ROOT_X86
+#  define GPT_USR_NATIVE GPT_USR_X86_64
+#  define GPT_USR_SECONDARY GPT_USR_X86
 #elif defined(__i386__)
 #  define GPT_ROOT_NATIVE GPT_ROOT_X86
+#  define GPT_USR_NATIVE GPT_USR_X86
 #endif
 
 #if defined(__aarch64__) && (__BYTE_ORDER != __BIG_ENDIAN)
 #  define GPT_ROOT_NATIVE GPT_ROOT_ARM_64
 #  define GPT_ROOT_SECONDARY GPT_ROOT_ARM
+#  define GPT_USR_NATIVE GPT_USR_ARM_64
+#  define GPT_USR_SECONDARY GPT_USR_ARM
 #elif defined(__arm__) && (__BYTE_ORDER != __BIG_ENDIAN)
 #  define GPT_ROOT_NATIVE GPT_ROOT_ARM
+#  define GPT_USR_NATIVE GPT_USR_ARM
 #endif
 
 /* Flags we recognize on the root, swap, home and srv partitions when


### PR DESCRIPTION
Just posting this as an FYI/RFC/whatever. It is a first pass at supporting CoreOS style disk images under systemd-nspawn. To keep things generic priority attributes can be used for both root and /usr partitions, CoreOS only uses them for /usr. For a description of the system see the original ChromiumOS documentation, with the exception that we are dealing with filesystem partitions here and not special kernel partitions. http://www.chromium.org/chromium-os/chromiumos-design-docs/disk-format#TOC-Trusting-the-GPT

As-is this doesn't quite work for CoreOS as it stands right now:
 - CoreOS images need to set the read-only flag (bit 60) in the GPT attributes for /usr
 - There is nothing to mark the booted partition as successful, update-engine currently doesn't run in containers.
 - Even if update-engine did run not all partitions are added to the container's /dev yet.

But it is a start, which I started almost a year ago and only now finished because libfdisk now does what I need it to: https://github.com/karelzak/util-linux/commit/4a4a0927c6b761f7b8b29b00491b22b3553720e8